### PR TITLE
fix: markdown buttons word wrap and overlap each other

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1023,6 +1023,8 @@ a.markdown-btn {
   text-decoration: none;
   border: none;
   cursor: pointer;
+  display: inline-block;
+  margin: 5px 0px;
 }
 
 a.markdown-btn:hover,


### PR DESCRIPTION
Resolves issue with wrapped text and no top/bottom margin on buttons.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/10994715/210192129-c533d5bc-8495-4e6f-8d58-7e42f8a58c1b.png">
