### PR TITLE
feat: add darkmode logo

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -66,7 +66,12 @@
       <div class="avatar-container">
         <div class="avatar-img-border">
           <a title="{{ .Site.Title }}" href="{{ "" | absLangURL }}">
-            <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}" />
+            <picture>
+              {{- with .Site.Params.darkLogo | default .Site.Params.logo }}
+              <source srcset="{{ . | absURL }}" media="(prefers-color-scheme:dark)">
+              {{- end }}
+              <img class="avatar-img" src="{{ .Site.Params.logo | absURL }}" alt="{{ .Site.Title }}">
+            </picture>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Set site .Params.darkLogo or it will default to the site logo

Dark Mode:

![image](https://user-images.githubusercontent.com/10994715/211404411-658d75e0-e749-419b-a428-85e0fcc4a16a.png)

Light Mode:

![image](https://user-images.githubusercontent.com/10994715/211404473-1bc83fc4-03e3-4e5f-bb7e-5429f65d24ba.png)
