### PR TITLE
fix: light mode for the markdown button

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1033,3 +1033,9 @@ a.markdown-btn:active {
   background-color: #0085a1;
   color: #FFFFFF;
 }
+
+@media (prefers-color-scheme: light) {
+  a.markdown-btn {
+    background-color: #DDDDDD;
+  }
+}


### PR DESCRIPTION
<img width="682" alt="image" src="https://user-images.githubusercontent.com/10994715/217118674-c1cd146c-7361-4830-a5f7-2601859f3f13.png">
